### PR TITLE
Hide header information

### DIFF
--- a/Controller/RobotsTxtController.php
+++ b/Controller/RobotsTxtController.php
@@ -18,7 +18,7 @@ class RobotsTxtController
 
     public function robotsTxtAction()
     {
-        $content = $this->templating->render('RicbraRobotsTxtBundle:RobotsTxt:robots.txt.twig', array(
+        $content = $this->templating->renderView('RicbraRobotsTxtBundle:RobotsTxt:robots.txt.twig', array(
             'allow_robots' => $this->allowRobots
         ));
 


### PR DESCRIPTION
The method render() will display header information.
Using method renderView(). This method will not display header information, just the generated html.