### PR TITLE
Remove deprecations

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,4 @@
 services:
     ricbra_robots_txt.robots_txt_controller:
         class: Ricbra\Bundle\RobotsTxtBundle\Controller\RobotsTxtController
-        arguments: ['@templating', %ricbra_robots_txt.allow_robots%]
+        arguments: ['@templating', '%ricbra_robots_txt.allow_robots%']


### PR DESCRIPTION
Parameters must be quoted too to avoid exception / deprecations (based on your Symfony version)